### PR TITLE
ci: change token

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,5 +44,5 @@ jobs:
         version: latest
         args: release --rm-dist
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
https://github.com/suzuki-shunsuke/yaml2json/runs/6289109642?check_suite_focus=true

```
   ⨯ release failed after 22.41s error=scm releases: failed to publish artifacts: POST https://api.github.com/repos/suzuki-shunsuke/yaml2json/releases: 403 Resource not accessible by integration []
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.8.3/x64/goreleaser' failed with exit code 1
```

I can't understand why it failed to release.
Let me try replace `github.token` to `secrets.GITHUB_TOKEN`.