### PR TITLE
feat: support indent

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -32,9 +32,10 @@ func (flags *LDFlags) ShowVersion() string {
 	return flags.Version + " (" + flags.Commit + ")"
 }
 
-func parseFlag(verFlag, helpFlag *bool) {
+func parseFlag(verFlag, helpFlag *bool, indentFlag *string) {
 	pflag.BoolVarP(verFlag, "version", "v", false, "show yaml2json's version")
 	pflag.BoolVarP(helpFlag, "help", "h", false, "show the help message")
+	pflag.StringVarP(indentFlag, "indent", "i", "", "indent")
 	pflag.Parse()
 }
 
@@ -44,14 +45,15 @@ const helpMsg = `NAME:
    https://github.com/suzuki-shunsuke/yaml2json
 
 USAGE:
-   yaml2json [--help, -h] [--version, -v]
+   yaml2json [--help, -h] [--version, -v] [--indent, -i ""]
 
 VERSION:
    %s
 
 OPTIONS:
    --help, -h           show help (default: false)
-   --version, -v        print the version (default: false)`
+   --version, -v        print the version (default: false)
+	 --indent, -i         indent (default: "")`
 
 var errFileRequired = errors.New("YAML file is required")
 
@@ -59,7 +61,7 @@ func (runner *Runner) Run(ctx context.Context, args ...string) error {
 	ctrl := controller.New(os.Stdout)
 	param := &controller.RunParam{}
 	verFlag, helpFlag := false, false
-	parseFlag(&verFlag, &helpFlag)
+	parseFlag(&verFlag, &helpFlag, &param.Indent)
 	if helpFlag {
 		fmt.Fprintf(runner.Stdout, helpMsg, runner.LDFlags.ShowVersion())
 		return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -22,7 +22,8 @@ func New(stdout io.Writer) *Controller {
 }
 
 type RunParam struct {
-	Path string
+	Path   string
+	Indent string
 }
 
 func (ctrl *Controller) Run(ctx context.Context, param *RunParam) error {
@@ -39,7 +40,9 @@ func (ctrl *Controller) Run(ctx context.Context, param *RunParam) error {
 	if err != nil {
 		return fmt.Errorf("convert map key from interface{} to string: %w", err)
 	}
-	if err := json.NewEncoder(ctrl.stdout).Encode(a); err != nil {
+	encoder := json.NewEncoder(ctrl.stdout)
+	encoder.SetIndent("", param.Indent)
+	if err := encoder.Encode(a); err != nil {
 		return fmt.Errorf("encode data as JSON: %w", err)
 	}
 	return nil


### PR DESCRIPTION
e.g.

```console
$ yaml2json aqua.yaml
{"packages":[{"name":"rhysd/actionlint@v1.6.12"},{"name":"golangci/golangci-lint@v1.45.2"},{"name":"reviewdog/reviewdog@v0.14.1"}],"registries":[{"ref":"v2.12.0","type":"standard"}]}
```

```console
$ yaml2json -i "  " aqua.yaml
{
  "packages": [
    {
      "name": "rhysd/actionlint@v1.6.12"
    },
    {
      "name": "golangci/golangci-lint@v1.45.2"
    },
    {
      "name": "reviewdog/reviewdog@v0.14.1"
    }
  ],
  "registries": [
    {
      "ref": "v2.12.0",
      "type": "standard"
    }
  ]
}
```